### PR TITLE
Create smbsvrtop.v5

### DIFF
--- a/payload/smbsvrtop.v5
+++ b/payload/smbsvrtop.v5
@@ -1,0 +1,459 @@
+#!/usr/bin/ksh
+#
+# smbvsvrtop.v4 - display top SMB I/O events on a server.
+#
+# This is measuring the response time between an incoming SMB operation
+# and its response. In general, this measures the server's view of how
+# quickly it can respond to requests. By default, the list shows responses
+# to each client.
+# 	
+# Top-level fields:
+#   load    1 min load average
+#   read    total KB read during sample
+#   write   total KB sync writes during sample
+#
+# The following per-client and "all" clients fields are shown
+#   Client  Client IPv4 address or workstation name
+#   SMBOPS  SMB operations per second
+#   Reads   Read operations per second
+#   Writes  Write operations per second
+#   Rd_bw   Read bandwidth KB/sec
+#   Wr_bw   Write bandwidth KB/sec
+#   Rd_t    Average read time in microseconds
+#   Wr_t    Average write time in microseconds
+#   Align%  Percentage of read/write operations that have offset aligned to
+#           blocksize (default=4096 bytes)
+#
+# Note: dtrace doesn't do floating point. A seemingly zero response or 
+# count can result due to integer division.
+# 
+#
+# INSPIRATION:  top(1) by William LeFebvre and iotop by Brendan Gregg
+#
+# Copyright 2019, Nexenta Systems, Inc. All rights reserved.
+# Copyright 2012, Richard Elling, All rights reserved.
+#
+# CDDL HEADER START
+#
+#  The contents of this file are subject to the terms of the
+#  Common Development and Distribution License, Version 1.0 only
+#  (the "License").  You may not use this file except in compliance
+#  with the License.
+#
+#  You can obtain a copy of the license at Docs/cddl1.txt
+#  or http://www.opensolaris.org/os/licensing.
+#  See the License for the specific language governing permissions
+#  and limitations under the License.
+#
+# CDDL HEADER END
+#
+# Author: Richard.Elling@Nexenta.com
+#
+# Revision:
+#   1.9	 29-Nov-2012
+#   1.10 27-Aug-2014 : Removed ReadRaw and WriteRaw probes as these don't exist in NS4.x
+#		       (Jason.Banham@Nexenta.COM)
+#   1.11  4-Apr-2019 : Update for SMB/SMB2 dtrace provider (GWR)
+#
+PATH=/usr/sbin:/usr/bin
+
+##############################
+# check to see if the SMB server module is loaded
+# if not, then the dtrace probes will fail ungracefully
+if [ "$(uname -s)" = "SunOS" ]; then
+	modinfo | awk '{print $6}' | grep -q smbsrv
+	if [ $? != 0 ]; then
+		echo "error: SMB server module is not loaded. Is the SMB service running?"
+		exit 1
+	fi
+fi
+
+##############################
+# --- Process Arguments ---
+#
+
+### default variables
+opt_blocksize=4096  # blocksize for alignment measurements
+opt_client=0        # set if -c option set
+opt_clear=1         # set if screen to be cleared
+opt_json=0          # set if output is JSON
+opt_share=0         # set if -s option set
+opt_top=0           # set if list trimmed to top
+opt_wsname=0        # set if workstation name desired rather than IPv4 addr
+top=0               # number of lines trimmed
+interval=10         # default interval
+count=-1            # number of intervals to show
+
+### process options
+while getopts b:c:Cjt:w name
+do
+    case $name in
+        b)  opt_blocksize=$OPTARG ;;
+        c)  opt_client=1; client_ws=$OPTARG ;;
+        C)  opt_clear=0 ;;
+        j)  opt_json=1 ;;
+        s)  opt_share=1; share_name=$OPTARG ;;
+        t)  opt_top=1; top=$OPTARG ;;
+        w)  opt_wsname=1 ;;
+        h|?)    cat <<END >&2
+USAGE: smbsvrtop [-Cj] [-b blocksize] [-c client_ws] [-s share_name] [-t top]
+                 [interval [count]]
+             -b blocksize # alignment blocksize (default=4096)
+             -c client_ws # trace for this client only
+             -C           # don't clear the screen
+             -j           # print output in JSON format
+             -s share_name # trace for this share only
+             -t top       # print top number of entries only
+             -w           # print workstation name instead of IPv4 addr
+   examples:
+     smbsvrtop         # default output, 10 second samples
+     smbsvrtop -b 1024 # check alignment on 1KB boundary
+     smbsvrtop 1       # 1 second samples
+     smbsvrtop -C 60   # 60 second samples, do not clear screen
+     smbsvrtop -t 20   # print top 20 lines only
+     smbsvrtop 5 12    # print 12 x 5 second samples
+END
+        exit 1
+    esac
+done
+
+shift $(($OPTIND - 1))
+
+### option logic
+if [ ! -z "$1" ]; then
+    interval=$1; shift
+fi
+if [ ! -z "$1" ]; then
+    count=$1; shift
+fi
+if [ $opt_clear = 1 ]; then
+    clearstr=$(clear)
+else
+    clearstr=""
+fi
+
+#################################
+# --- Main Program, DTrace ---
+#
+/usr/sbin/dtrace -Cn '
+/*
+ * smbsvrtop - Command line arguments
+ */
+inline int OPT_blocksize = '$opt_blocksize';
+inline int OPT_clear 	= '$opt_clear';
+inline int OPT_client   = '$opt_client';
+inline int OPT_share    = '$opt_share';
+inline int OPT_top 	= '$opt_top';
+inline int OPT_json	= '$opt_json';
+inline int OPT_wsname = '$opt_wsname';
+inline int INTERVAL 	= '$interval';
+inline int COUNTER 	= '$count';
+inline int TOP          = '$top';
+inline string CLIENT	= "'$client_ws'";
+inline string CLEAR 	= "'$clearstr'";
+inline string SHARE	= "'$share_name'";
+
+#pragma D option quiet
+
+/* increase dynvarsize if you get "dynamic variable drops" */
+#pragma D option dynvarsize=8m
+
+/*
+ * Print header
+ */
+dtrace:::BEGIN 
+{
+    /* starting values */
+    counts = COUNTER;
+    secs = INTERVAL;
+    total_read_bw = 0;
+    total_write_bw = 0;
+
+    printf("Tracing... Please wait.\n");
+}
+
+/*
+ * Filter as needed, based on starts
+ *
+ * Unfortunately, trying to write this as:
+ *	smb:::op-*-start {}
+ *	smb:::op-*-done {}
+ * fails to compile with this complaint:
+ *	dtrace: failed to compile script ...: line NN:
+ *	args[ ] may not be referenced because probe description
+ *	smb:::op-*-start matches an unstable set of probes
+ *
+ * Not clear why listing them all is necessary, but that works.
+ */
+smb:::op-CheckDirectory-start,
+smb:::op-Close-start,
+smb:::op-CloseAndTreeDisconnect-start,
+smb:::op-ClosePrintFile-start,
+smb:::op-Create-start,
+smb:::op-CreateDirectory-start,
+smb:::op-CreateNew-start,
+smb:::op-CreateTemporary-start,
+smb:::op-Delete-start,
+smb:::op-DeleteDirectory-start,
+smb:::op-Echo-start,
+smb:::op-Find-start,
+smb:::op-FindClose-start,
+smb:::op-FindClose2-start,
+smb:::op-FindUnique-start,
+smb:::op-Flush-start,
+smb:::op-GetPrintQueue-start,
+smb:::op-Invalid-start,
+smb:::op-Ioctl-start,
+smb:::op-LockAndRead-start,
+smb:::op-LockByteRange-start,
+smb:::op-LockingX-start,
+smb:::op-LogoffX-start,
+smb:::op-Negotiate-start,
+smb:::op-NtCancel-start,
+smb:::op-NtCreateX-start,
+smb:::op-NtRename-start,
+smb:::op-NtTransact-start,
+smb:::op-NtTransactCreate-start,
+smb:::op-NtTransactSecondary-start,
+smb:::op-Open-start,
+smb:::op-OpenPrintFile-start,
+smb:::op-OpenX-start,
+smb:::op-ProcessExit-start,
+smb:::op-QueryInformation-start,
+smb:::op-QueryInformation2-start,
+smb:::op-QueryInformationDisk-start,
+smb:::op-Read-start,
+smb:::op-ReadRaw-start,
+smb:::op-ReadX-start,
+smb:::op-Rename-start,
+smb:::op-Search-start,
+smb:::op-Seek-start,
+smb:::op-SessionSetupX-start,
+smb:::op-SetInformation-start,
+smb:::op-SetInformation2-start,
+smb:::op-Transaction-start,
+smb:::op-Transaction2-start,
+smb:::op-Transaction2Secondary-start,
+smb:::op-TransactionSecondary-start,
+smb:::op-TreeConnect-start,
+smb:::op-TreeConnectX-start,
+smb:::op-TreeDisconnect-start,
+smb:::op-UnlockByteRange-start,
+smb:::op-Write-start,
+smb:::op-WriteAndClose-start,
+smb:::op-WriteAndUnlock-start,
+smb:::op-WritePrintFile-start,
+smb:::op-WriteRaw-start,
+smb:::op-WriteX-start,
+smb2:::op-Cancel-start,
+smb2:::op-ChangeNotify-start,
+smb2:::op-Close-start,
+smb2:::op-Create-start,
+smb2:::op-Echo-start,
+smb2:::op-Flush-start,
+smb2:::op-Ioctl-start,
+smb2:::op-Lock-start,
+smb2:::op-Logoff-start,
+smb2:::op-Negotiate-start,
+smb2:::op-OplockBreak-start,
+smb2:::op-QueryDirectory-start,
+smb2:::op-QueryInfo-start,
+smb2:::op-Read-start,
+smb2:::op-SessionSetup-start,
+smb2:::op-SetInfo-start,
+smb2:::op-TreeConnect-start,
+smb2:::op-TreeDisconnect-start,
+smb2:::op-Write-start
+/((OPT_client == 0 || CLIENT == args[0]->ci_remote) &&
+  (OPT_share == 0  || SHARE == args[1]->soi_share))/
+{ 
+    this->me = args[0]->ci_remote;
+
+    @c_smbops[this->me] = count();
+    OPT_client == 0 ? @c_smbops["all"] = count() : 1;
+}
+
+smb:::op-ReadX-start,
+smb:::op-Read-start,
+smb:::op-WriteX-start,
+smb:::op-Write-start,
+smb2:::op-Read-start,
+smb2:::op-Write-start
+/((OPT_client == 0 || CLIENT == args[0]->ci_remote) &&
+  (OPT_share == 0  || SHARE == args[1]->soi_share))/
+{ 
+    self->startts = timestamp;
+}
+
+/*
+ * read
+ */
+smb:::op-ReadX-start,
+smb:::op-Read-start,
+smb2:::op-Read-start
+/self->startts/
+{
+    this->me = args[0]->ci_remote;
+    this->rw_count = args[2]->soa_count;
+    this->rw_offset = args[2]->soa_offset;
+
+    @c_read[this->me] = count();
+    OPT_client == 0 ? @c_read["all"] = count() : 1;
+    @read_bw[this->me] = sum(this->rw_count);
+    OPT_client == 0 ? @read_bw["all"] = sum(this->rw_count) : 1;
+    total_read_bw += this->rw_count;
+    @avg_aligned[this->me] = 
+        avg((this->rw_offset % OPT_blocksize) ? 0 : 100);
+    @avg_aligned["all"] = 
+        avg((this->rw_offset % OPT_blocksize) ? 0 : 100);
+}
+
+smb:::op-ReadX-done,
+smb:::op-Read-done,
+smb2:::op-Read-done
+/self->startts/
+{
+    this->me = args[0]->ci_remote;
+
+    t = timestamp - self->startts;
+    @avgtime_read[this->me] = avg(t);
+    OPT_client == 0 ? @avgtime_read["all"] = avg(t) : 1;
+    self->startts = 0;
+}
+
+/*
+ * write
+ */
+smb:::op-WriteX-start,
+smb:::op-Write-start,
+smb2:::op-Write-start
+/self->startts/
+{
+    this->me = args[0]->ci_remote;
+    this->rw_count = args[2]->soa_count;
+    this->rw_offset = args[2]->soa_offset;
+
+    @c_write[this->me] = count();
+    OPT_client == 0 ? @c_write["all"] = count() : 1;
+    @write_bw[this->me] = sum(this->rw_count);
+    OPT_client == 0 ? @write_bw["all"] = sum(this->rw_count) : 1;
+    total_write_bw += this->rw_count;
+    @avg_aligned[this->me] = 
+        avg((this->rw_offset % OPT_blocksize) ? 0 : 100);
+    @avg_aligned["all"] = 
+        avg((this->rw_offset % OPT_blocksize) ? 0 : 100);
+}
+
+smb:::op-WriteX-done,
+smb:::op-Write-done,
+smb2:::op-Write-done
+/self->startts/
+{
+	this->me = args[0]->ci_remote;
+
+	t = timestamp - self->startts;
+	@avgtime_write[this->me] = avg(t);
+	OPT_client == 0 ? @avgtime_write["all"] = avg(t) : 1;
+	self->startts = 0;
+}
+
+/*
+ * timer
+ */
+profile:::tick-1sec
+{
+	secs--;
+}
+
+/*
+ * Print report
+ */
+profile:::tick-1sec
+/secs == 0/
+{	
+    /* fetch 1 min load average */
+    self->load1a = `hp_avenrun[0] / 65536;
+    self->load1b = ((`hp_avenrun[0] % 65536) * 100) / 65536;
+
+    /* convert counters to Kbytes */
+    total_read_bw /= 1024;
+    total_write_bw /= 1024;
+
+    /* normalize to seconds giving a rate */
+    /* todo: this should be measured, not based on the INTERVAL */
+    normalize(@c_smbops, INTERVAL);
+    normalize(@c_read, INTERVAL);
+    normalize(@c_write, INTERVAL);
+
+    /* normalize to KB per second */
+    normalize(@read_bw, 1024 * INTERVAL);
+    normalize(@write_bw, 1024 * INTERVAL);
+
+    /* normalize average to microseconds */
+    normalize(@avgtime_read, 1000);
+    normalize(@avgtime_write, 1000);
+
+    /* print status */
+    OPT_clear && !OPT_json ? printf("%s", CLEAR) : 1;
+
+    OPT_json ? 
+        printf("{ \"collector\": \"smbsvrtop\", \"time\": \"%Y\", \"timestamp\": %d, \"interval\": %d, \"load\": %d.%02d, \"read_KB_int\": %d, \"write_KB_int\": %d, \"clientdata\": [",
+            walltimestamp, walltimestamp, INTERVAL, 
+            self->load1a, self->load1b, 
+            total_read_bw, total_write_bw)
+    :
+        printf("%Y, load: %d.%02d, read: %-8d KB, write: %-8d KB\n",
+            walltimestamp, self->load1a, self->load1b, 
+            total_read_bw, total_write_bw);
+
+    /* print headers */
+    OPT_json ? 1 :
+        printf("%-15s\t%7s\t%7s\t%7s\t%7s\t%7s\t%7s\t%7s\t%7s\n",
+            "Client", "SMBOPS", 
+            "Reads", "Writes", "Rd_bw", "Wr_bw", "Rd_t", "Wr_t", "Align%");
+
+    /* truncate to top lines if needed */
+    OPT_top ? trunc(@c_smbops, TOP) : 1;
+
+    OPT_json ?
+        printa("{\"client\": \"%s\", \"SMBOPS\": %@d, \"reads\": %@d, \"writes\": %@d, \"read_bw\": %@d, \"write_bw\": %@d, \"avg_read_t\": %@d, \"avg_write_t\": %@d, \"aligned_pct\": %@d },",
+            @c_smbops, @c_read, @c_write, @read_bw, @write_bw,
+            @avgtime_read, @avgtime_write, @avg_aligned)
+    :
+        printa("%-15s\t%7@d\t%7@d\t%7@d\t%7@d\t%7@d\t%7@d\t%7@d\t%7@d\n",
+            @c_smbops, @c_read, @c_write, @read_bw, @write_bw,
+            @avgtime_read, @avgtime_write, @avg_aligned);
+
+    OPT_json ? printf("{}]}\n") : 1;
+
+    /* clear data */
+    trunc(@c_smbops); trunc(@c_read); trunc(@c_write); 
+    trunc(@read_bw); trunc(@write_bw); 
+    trunc(@avgtime_read); trunc(@avgtime_write);
+    trunc(@avg_aligned);
+    total_read_bw = 0;
+    total_write_bw = 0;
+    secs = INTERVAL;
+    counts--;
+}
+
+/*
+ * end of program 
+ */
+profile:::tick-1sec
+/counts == 0/
+{
+	exit(0);
+}
+
+/*
+ * clean up when interrupted
+ */
+dtrace:::END
+{
+    trunc(@c_smbops); trunc(@c_read); trunc(@c_write); 
+    trunc(@read_bw); trunc(@write_bw); 
+    trunc(@avgtime_read); trunc(@avgtime_write);
+    trunc(@avg_aligned);
+}
+'


### PR DESCRIPTION
In NexentaStor 5.2.0 and later, all the SMB server dtrace probes are now
presented via the (new) smb and smb2 dtrace providers.
This script uses those new providers.